### PR TITLE
Permit params to prevent argument error in rails 5

### DIFF
--- a/app/views/searchjoy/searches/index.html.erb
+++ b/app/views/searchjoy/searches/index.html.erb
@@ -7,9 +7,9 @@
   <thead>
     <tr>
       <th>Query</th>
-      <th class="num" style="width: 20%;"><%= link_to "Searches", params.except(:sort), class: ("active" if params[:sort] != "conversion_rate") %></th>
+      <th class="num" style="width: 20%;"><%= link_to "Searches", params.permit!.except(:sort), class: ("active" if params[:sort] != "conversion_rate") %></th>
       <th class="num" style="width: 20%;">Conversions</th>
-      <th class="num" style="width: 20%;"><%= link_to "%", params.merge(sort: "conversion_rate"), class: ("active" if params[:sort] == "conversion_rate") %></th>
+      <th class="num" style="width: 20%;"><%= link_to "%", params.permit!.merge(sort: "conversion_rate"), class: ("active" if params[:sort] == "conversion_rate") %></th>
       <th class="num" style="width: 20%;">Avg Results</th>
     </tr>
   </thead>


### PR DESCRIPTION
When viewing all searches, rails 5 throw this error
```
Attempting to generate a URL from non-sanitized request parameters! An attacker can inject malicious data into the generated URL, such as changing the host. Whitelist and sanitize passed parameters to be secure.
```